### PR TITLE
Use "license" field instead of "licence"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers"
 ]
-licence = "MIT"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/starhel/dataslots"
 keywords=['dataslots', 'slots', 'dataclasses']


### PR DESCRIPTION
I've tried to install the package from git with `pip install git+https://github.com/starhel/dataslots.git` but installation failed: `Additional properties are not allowed ('licence' was unexpected)`. According to [poetry docs](https://python-poetry.org/docs/pyproject/#license) pyproject.toml has field "license" instead of "licence". Changing field name allowed to install package without any errors.