### PR TITLE
Enable mypy tests for dataslots.dataclass (supported from mypy>=1.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,9 @@ Check example directory for basic usage.
 _Added in 1.1.0_
 
 ### Typing support (PEP 561)
-The package is PEP 561 compliant, so you can easily use it with mypy<sup>1</sup> and pyright.
+The package is PEP 561 compliant, so you can easily use it with `mypy>=1.1.1`<sup>1</sup> and `pyright`.
 
-<sup>1</sup> Due to some issues in mypy not all features are supported correctly (like [dataclass alike 
-interface](https://github.com/python/mypy/issues/14293) or [descriptors](https://github.com/python/mypy/issues/13856)). 
+<sup>1</sup> Due to some issues in mypy not all features are supported correctly (known bugs: [descriptors](https://github.com/python/mypy/issues/13856)). 
 
 _Added in 1.2.0_
 

--- a/tox.ini
+++ b/tox.ini
@@ -39,12 +39,11 @@ commands =
 basepython = python3.11
 deps =
     {[testenv]deps}
-    mypy
+    mypy>=1.1.1
     pyright
 commands =
     # test_descriptor: https://github.com/python/mypy/issues/13856
-    # test_backport: https://github.com/python/mypy/issues/14293
-    mypy src tests --exclude tests/test_backport.py --exclude tests/test_descriptor.py --check-untyped-defs
+    mypy src tests --exclude tests/test_descriptor.py --check-untyped-defs
     pyright src tests
 
 [testenv:coverage]


### PR DESCRIPTION
From [mypy blog](https://mypy-lang.blogspot.com/2023/03/mypy-111-released.html):
> Support for dataclass_transform
> 
> This release adds full support for the dataclass_transform decorator defined in [PEP 681](https://peps.python.org/pep-0681/#decorator-function-example). This allows decorators, base classes, and metaclasses that generate a __init__ method or other methods based on the properties of that class (similar to dataclasses) to have those methods recognized by mypy.
> 
> This was contributed by Wesley Collin Wright.

There's still some work to do, as https://github.com/python/mypy/issues/14293 is not closed, but it does not affect dataslots tests. 